### PR TITLE
Add responsive design adjustments for grid and overlay components

### DIFF
--- a/components/Landing/Grid/grid.module.scss
+++ b/components/Landing/Grid/grid.module.scss
@@ -1,5 +1,14 @@
 .grid {
     position: absolute;
     z-index: -11;
-    width: 100vw;
+
+    @media (width > 735px) {
+        width: 100vw;
+    }
+
+    @media (width <= 735px) {
+        aspect-ratio: 1 / 1;
+        height: 100dvh;
+        object-fit: cover;
+    }
 }

--- a/components/Landing/LandingOverlay/overlay.module.scss
+++ b/components/Landing/LandingOverlay/overlay.module.scss
@@ -23,6 +23,10 @@
         bottom: 0;
         z-index: 10;
 
+        @media (width <= 1000px) {
+            display: none;
+        }
+
         .cards {
             position: relative;
             top: -4rem;


### PR DESCRIPTION
- Adjust grid width and height based on screen width using media queries.
- Hide overlay on screens smaller than 1000px.